### PR TITLE
Remove notification feature

### DIFF
--- a/Sources/ConfigurationManager.swift
+++ b/Sources/ConfigurationManager.swift
@@ -142,7 +142,6 @@ struct AppConfiguration: Codable {
     let maxTokens: Int
     let timeout: TimeInterval
     let showStatusIcon: Bool
-    let enableNotifications: Bool
     let autoSave: Bool
     let logLevel: String
     let apiProviders: APIProviders
@@ -163,7 +162,6 @@ struct AppConfiguration: Codable {
         maxTokens: 1000,
         timeout: 30.0,
         showStatusIcon: true,
-        enableNotifications: true,
         autoSave: true,
         logLevel: "info",
         apiProviders: APIProviders.default

--- a/Sources/MenuBarManager.swift
+++ b/Sources/MenuBarManager.swift
@@ -1,6 +1,5 @@
 import AppKit
 import SwiftUI
-import UserNotifications
 
 class MenuBarManager: ObservableObject {
     private let shortcutManager: ShortcutManager
@@ -43,10 +42,6 @@ class MenuBarManager: ObservableObject {
             object: nil
         )
         
-        // Request notification permissions if enabled
-        if configManager.configuration.enableNotifications {
-            requestNotificationPermissions()
-        }
         
         // Set initial accessibility status and log it
         lastAccessibilityStatus = AXIsProcessTrusted()
@@ -457,7 +452,6 @@ class MenuBarManager: ObservableObject {
             self.isProcessing = true
             self.updateStatusIcon()
             self.startProcessingAnimation()
-            self.showNotification(title: "TextEnhancer", message: "Processing text...", isStarting: true)
         }
     }
     
@@ -468,7 +462,6 @@ class MenuBarManager: ObservableObject {
             self.retryInfo = nil
             self.stopProcessingAnimation()
             self.updateStatusIcon()
-            self.showNotification(title: "TextEnhancer", message: "Text enhancement complete!", isStarting: false)
         }
     }
     
@@ -637,56 +630,6 @@ class MenuBarManager: ObservableObject {
         }
     }
     
-    private func requestNotificationPermissions() {
-        // Check if we're running in a proper app bundle and not from swift run
-        guard Bundle.main.bundleIdentifier != nil,
-              !Bundle.main.bundlePath.contains("/.build/") else {
-            print("ℹ️  Skipping notification permissions request - not running in app bundle")
-            return
-        }
-        
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
-            if let error = error {
-                print("⚠️  Notification permission error: \(error)")
-            } else if granted {
-                print("✅ Notification permissions granted")
-            } else {
-                print("❌ Notification permissions denied")
-            }
-        }
-    }
-    
-    private func showNotification(title: String, message: String, isStarting: Bool) {
-        guard configManager.configuration.enableNotifications else { return }
-        
-        // Check if we're running in a proper app bundle and not from swift run
-        guard Bundle.main.bundleIdentifier != nil,
-              !Bundle.main.bundlePath.contains("/.build/") else {
-            print("ℹ️  Skipping notification - not running in app bundle")
-            return
-        }
-        
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = message
-        content.sound = UNNotificationSound.default
-        
-        // Different icons for different states
-        if isStarting {
-            content.badge = 1
-        } else {
-            content.badge = 0
-        }
-        
-        let identifier = isStarting ? "text-processing-started" : "text-processing-finished"
-        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
-        
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error = error {
-                print("⚠️  Failed to show notification: \(error)")
-            }
-        }
-    }
     
     deinit {
         animationTimer?.invalidate()

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -51,7 +51,6 @@ struct SettingsView: View {
     @State private var maxTokens: Int
     @State private var timeout: Double
     @State private var showStatusIcon: Bool
-    @State private var enableNotifications: Bool
     @State private var claudeApiKey: String
     @State private var openaiApiKey: String
     @State private var claudeEnabled: Bool
@@ -73,7 +72,6 @@ struct SettingsView: View {
         self._maxTokens = State(initialValue: config.maxTokens)
         self._timeout = State(initialValue: config.timeout)
         self._showStatusIcon = State(initialValue: config.showStatusIcon)
-        self._enableNotifications = State(initialValue: config.enableNotifications)
         self._claudeApiKey = State(initialValue: config.apiProviders.claude.apiKey)
         self._openaiApiKey = State(initialValue: config.apiProviders.openai.apiKey)
         self._claudeEnabled = State(initialValue: config.apiProviders.claude.enabled)
@@ -297,9 +295,6 @@ struct SettingsView: View {
                             Toggle("Show Status Icon", isOn: $showStatusIcon)
                                 .font(.subheadline)
                                 .onChange(of: showStatusIcon) { _ in saveConfiguration() }
-                            Toggle("Enable Notifications", isOn: $enableNotifications)
-                                .font(.subheadline)
-                                .onChange(of: enableNotifications) { _ in saveConfiguration() }
                         }
                         .padding(.vertical, 4)
                     }
@@ -346,7 +341,6 @@ struct SettingsView: View {
             maxTokens: maxTokens,
             timeout: timeout,
             showStatusIcon: showStatusIcon,
-            enableNotifications: enableNotifications,
             autoSave: configManager.configuration.autoSave,
             logLevel: configManager.configuration.logLevel,
             apiProviders: APIProviders(

--- a/Tests/SimpleTestRunner.swift
+++ b/Tests/SimpleTestRunner.swift
@@ -63,7 +63,6 @@ class SimpleTestRunner {
             maxTokens: 2000,
             timeout: 60.0,
             showStatusIcon: false,
-            enableNotifications: false,
             autoSave: false,
             logLevel: "debug"
         )

--- a/Tests/TextEnhancerTests/ClaudeServiceTests.swift
+++ b/Tests/TextEnhancerTests/ClaudeServiceTests.swift
@@ -34,7 +34,6 @@ final class ClaudeServiceTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(
@@ -287,7 +286,6 @@ final class ClaudeServiceTests: XCTestCase {
             maxTokens: currentConfig.maxTokens,
             timeout: currentConfig.timeout,
             showStatusIcon: currentConfig.showStatusIcon,
-            enableNotifications: currentConfig.enableNotifications,
             autoSave: currentConfig.autoSave,
             logLevel: currentConfig.logLevel,
             apiProviders: modifiedApiProviders

--- a/Tests/TextEnhancerTests/ConfigurationManagerDefaultConfigTests.swift
+++ b/Tests/TextEnhancerTests/ConfigurationManagerDefaultConfigTests.swift
@@ -28,7 +28,6 @@ final class ConfigurationManagerDefaultConfigTests: XCTestCase {
         XCTAssertEqual(configManager.configuration.maxTokens, 1000)
         XCTAssertEqual(configManager.configuration.timeout, 30.0)
         XCTAssertTrue(configManager.configuration.showStatusIcon)
-        XCTAssertTrue(configManager.configuration.enableNotifications)
         XCTAssertTrue(configManager.configuration.autoSave)
         XCTAssertEqual(configManager.configuration.logLevel, "info")
     }
@@ -65,7 +64,6 @@ final class ConfigurationManagerDefaultConfigTests: XCTestCase {
             maxTokens: 2000,
             timeout: 60.0,
             showStatusIcon: false,
-            enableNotifications: false,
             autoSave: false,
             logLevel: "debug",
             apiProviders: APIProviders(
@@ -91,7 +89,6 @@ final class ConfigurationManagerDefaultConfigTests: XCTestCase {
         XCTAssertEqual(configManager.configuration.maxTokens, 2000)
         XCTAssertEqual(configManager.configuration.timeout, 60.0)
         XCTAssertFalse(configManager.configuration.showStatusIcon)
-        XCTAssertFalse(configManager.configuration.enableNotifications)
         XCTAssertFalse(configManager.configuration.autoSave)
         XCTAssertEqual(configManager.configuration.logLevel, "debug")
         XCTAssertEqual(configManager.configuration.apiProviders.claude.apiKey, "test-claude-key")

--- a/Tests/TextEnhancerTests/ConfigurationManagerTests.swift
+++ b/Tests/TextEnhancerTests/ConfigurationManagerTests.swift
@@ -25,7 +25,6 @@ final class ConfigurationManagerTests: XCTestCase {
         XCTAssertEqual(configManager.configuration.maxTokens, 1000)
         XCTAssertEqual(configManager.configuration.timeout, 30.0)
         XCTAssertTrue(configManager.configuration.showStatusIcon)
-        XCTAssertTrue(configManager.configuration.enableNotifications)
         XCTAssertTrue(configManager.configuration.autoSave)
         XCTAssertEqual(configManager.configuration.logLevel, "info")
         XCTAssertEqual(configManager.configuration.shortcuts.count, 1)
@@ -50,7 +49,6 @@ final class ConfigurationManagerTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(
@@ -94,7 +92,6 @@ final class ConfigurationManagerTests: XCTestCase {
             maxTokens: 2000,
             timeout: 60.0,
             showStatusIcon: false,
-            enableNotifications: false,
             autoSave: false,
             logLevel: "debug",
             apiProviders: APIProviders(
@@ -126,7 +123,6 @@ final class ConfigurationManagerTests: XCTestCase {
             maxTokens: 1500,
             timeout: 45.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "warn",
             apiProviders: APIProviders(

--- a/Tests/TextEnhancerTests/MenuBarManagerTests.swift
+++ b/Tests/TextEnhancerTests/MenuBarManagerTests.swift
@@ -32,7 +32,6 @@ class MenuBarManagerTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: false, // Disable notifications to avoid UserNotifications issues in tests
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(
@@ -167,8 +166,4 @@ class MenuBarManagerTests: XCTestCase {
         XCTAssertNotNil(textProcessor)
     }
     
-    func testNotificationConfigurationRespected() {
-        // Test that notification settings are respected (should be disabled in test)
-        XCTAssertFalse(configManager.configuration.enableNotifications, "Notifications should be disabled in test configuration")
-    }
 } 

--- a/Tests/TextEnhancerTests/OpenAIServiceTests.swift
+++ b/Tests/TextEnhancerTests/OpenAIServiceTests.swift
@@ -34,7 +34,6 @@ final class OpenAIServiceTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(
@@ -261,7 +260,6 @@ final class OpenAIServiceTests: XCTestCase {
             maxTokens: currentConfig.maxTokens,
             timeout: currentConfig.timeout,
             showStatusIcon: currentConfig.showStatusIcon,
-            enableNotifications: currentConfig.enableNotifications,
             autoSave: currentConfig.autoSave,
             logLevel: currentConfig.logLevel,
             apiProviders: modifiedApiProviders

--- a/Tests/TextEnhancerTests/SettingsViewTests.swift
+++ b/Tests/TextEnhancerTests/SettingsViewTests.swift
@@ -62,7 +62,6 @@ class SettingsViewTests: XCTestCase {
             maxTokens: 2000,
             timeout: 60.0,
             showStatusIcon: false,
-            enableNotifications: false,
             autoSave: false,
             logLevel: "debug",
             apiProviders: APIProviders(
@@ -175,7 +174,6 @@ class SettingsViewTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(
@@ -204,7 +202,6 @@ class SettingsViewTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(

--- a/Tests/TextEnhancerTests/ShortcutManagerTests.swift
+++ b/Tests/TextEnhancerTests/ShortcutManagerTests.swift
@@ -49,7 +49,6 @@ final class ShortcutManagerTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(
@@ -111,7 +110,6 @@ final class ShortcutManagerTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(
@@ -143,7 +141,6 @@ final class ShortcutManagerTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(

--- a/Tests/TextEnhancerTests/ShortcutMenuControllerTests.swift
+++ b/Tests/TextEnhancerTests/ShortcutMenuControllerTests.swift
@@ -30,7 +30,6 @@ final class ShortcutMenuControllerTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: false,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders.default

--- a/Tests/TextEnhancerTests/TextProcessorTests.swift
+++ b/Tests/TextEnhancerTests/TextProcessorTests.swift
@@ -100,7 +100,6 @@ final class TextProcessorTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(
@@ -303,7 +302,6 @@ final class TextProcessorTests: XCTestCase {
             maxTokens: 1000,
             timeout: 30.0,
             showStatusIcon: true,
-            enableNotifications: true,
             autoSave: true,
             logLevel: "info",
             apiProviders: APIProviders(

--- a/TextEnhancer/ConfigurationManager.swift
+++ b/TextEnhancer/ConfigurationManager.swift
@@ -144,7 +144,6 @@ struct AppConfiguration: Codable {
     let maxTokens: Int
     let timeout: TimeInterval
     let showStatusIcon: Bool
-    let enableNotifications: Bool
     let autoSave: Bool
     let logLevel: String
     let apiProviders: APIProviders
@@ -165,7 +164,6 @@ struct AppConfiguration: Codable {
         maxTokens: 1000,
         timeout: 30.0,
         showStatusIcon: true,
-        enableNotifications: true,
         autoSave: true,
         logLevel: "info",
         apiProviders: APIProviders.default

--- a/TextEnhancer/SettingsView.swift
+++ b/TextEnhancer/SettingsView.swift
@@ -51,7 +51,6 @@ struct SettingsView: View {
     @State private var maxTokens: Int
     @State private var timeout: Double
     @State private var showStatusIcon: Bool
-    @State private var enableNotifications: Bool
     @State private var claudeApiKey: String
     @State private var openaiApiKey: String
     @State private var claudeEnabled: Bool
@@ -73,7 +72,6 @@ struct SettingsView: View {
         self._maxTokens = State(initialValue: config.maxTokens)
         self._timeout = State(initialValue: config.timeout)
         self._showStatusIcon = State(initialValue: config.showStatusIcon)
-        self._enableNotifications = State(initialValue: config.enableNotifications)
         self._claudeApiKey = State(initialValue: config.apiProviders.claude.apiKey)
         self._openaiApiKey = State(initialValue: config.apiProviders.openai.apiKey)
         self._claudeEnabled = State(initialValue: config.apiProviders.claude.enabled)
@@ -302,9 +300,6 @@ struct SettingsView: View {
                             Toggle("Show Status Icon", isOn: $showStatusIcon)
                                 .font(.subheadline)
                                 .onChange(of: showStatusIcon) { saveConfiguration() }
-                            Toggle("Enable Notifications", isOn: $enableNotifications)
-                                .font(.subheadline)
-                                .onChange(of: enableNotifications) { saveConfiguration() }
                         }
                         .padding(.vertical, 4)
                     }
@@ -351,7 +346,6 @@ struct SettingsView: View {
             maxTokens: maxTokens,
             timeout: timeout,
             showStatusIcon: showStatusIcon,
-            enableNotifications: enableNotifications,
             autoSave: configManager.configuration.autoSave,
             logLevel: configManager.configuration.logLevel,
             apiProviders: APIProviders(

--- a/TextEnhancer/config.default.json
+++ b/TextEnhancer/config.default.json
@@ -1,7 +1,6 @@
 {
   "showStatusIcon": true,
   "timeout": 30,
-  "enableNotifications": true,
   "apiProviders": {
     "claude": {
       "model": "claude-3-5-sonnet-20241022",

--- a/config.default.json
+++ b/config.default.json
@@ -1,7 +1,6 @@
 {
   "showStatusIcon": true,
   "timeout": 30,
-  "enableNotifications": true,
   "apiProviders": {
     "claude": {
       "model": "claude-3-5-sonnet-20241022",

--- a/docs/CONFIG_README.md
+++ b/docs/CONFIG_README.md
@@ -42,7 +42,6 @@ TextEnhancer now uses JSON-based configuration instead of a settings UI. This pr
 
 ### UI Settings
 - `showStatusIcon`: Show/hide the menu bar icon (default: true)
-- `enableNotifications`: Enable system notifications (default: true)
 - `logLevel`: Logging level ("debug", "info", "warning", "error")
 
 ### Shortcuts

--- a/docs/PHASE2_KICKOFF.md
+++ b/docs/PHASE2_KICKOFF.md
@@ -174,7 +174,6 @@ main.swift
   ],
   "ui": {
     "showProcessingIndicator": true,
-    "enableNotifications": true,
     "animateMenuBarIcon": true
   }
 }


### PR DESCRIPTION
## Summary
- drop enableNotifications from configuration and docs
- strip notification permission and alert code
- clean up UI toggle for notifications
- update tests for new configuration

## Testing
- `swift test` *(fails: no such module 'Carbon')*

------
https://chatgpt.com/codex/tasks/task_e_68890c116e6483219e0d299469732183