### PR TITLE
[codex] Fix docs workflow and local build validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'Sources/**'
+      - 'TextEnhancer/**'
       - 'docs/**'
       - '.github/workflows/docs.yml'
   pull_request:
     branches: [ main ]
     paths:
-      - 'Sources/**'
+      - 'TextEnhancer/**'
       - 'docs/**'
       - '.github/workflows/docs.yml'
 
@@ -22,6 +22,9 @@ permissions:
 concurrency:
   group: "pages"
   cancel-in-progress: true
+
+env:
+  SOURCE_DIR: TextEnhancer
 
 jobs:
   # Generate Swift documentation
@@ -64,7 +67,7 @@ jobs:
         echo "" >> docs/generated/index.md
         
         # Find public classes, structs, and protocols
-        find Sources/ -name "*.swift" -exec grep -l "public\|open" {} \; | while read file; do
+        find "$SOURCE_DIR" -name "*.swift" -exec grep -l "public\|open" {} \; | while read file; do
           echo "Processing $file"
           basename=$(basename "$file" .swift)
           echo "- [$basename](sources/$basename.md)" >> docs/generated/index.md
@@ -85,7 +88,7 @@ jobs:
 
     - name: Upload Documentation Artifact
       if: github.ref == 'refs/heads/main'
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v4
       with:
         path: docs/
 
@@ -123,7 +126,7 @@ jobs:
         # Check for public APIs without documentation
         missing_docs=0
         
-        find Sources/ -name "*.swift" | while read file; do
+        find "$SOURCE_DIR" -name "*.swift" | while read file; do
           echo "Checking $file"
           
           # Look for public declarations that might need documentation

--- a/TextEnhancer/Logger.swift
+++ b/TextEnhancer/Logger.swift
@@ -19,13 +19,22 @@ final class Logger {
 
         logFileURL = logsDir.appendingPathComponent("debug.log")
 
+        // Timestamp header for each session
+        let header = "\n=== TextEnhancer log started: \(Date()) ===\nVersion: \(AppVersion.fullVersion)\n"
+        if let data = header.data(using: .utf8),
+           let fileHandle = try? FileHandle(forWritingTo: logFileURL) {
+            do {
+                try fileHandle.seekToEnd()
+                try fileHandle.write(contentsOf: data)
+            } catch {
+                // Logging must never prevent the app from launching.
+            }
+            fileHandle.closeFile()
+        }
+
         // Redirect both stdout and stderr to the same log file (append-mode)
         let path = (logFileURL.path as NSString).fileSystemRepresentation
         freopen(path, "a+", stdout)
         freopen(path, "a+", stderr)
-
-        // Timestamp header for each session
-        let header = "\n=== TextEnhancer log started: \(Date()) ===\n"
-        fputs(header, stderr)
     }
 }

--- a/TextEnhancer/main.swift
+++ b/TextEnhancer/main.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // MARK: - Version Management
 
 enum AppVersion {
-    static let buildNumber: Int = 1023
+    static let buildNumber: Int = 1024
     static let version: String = "1.0.3"
     static let fullVersion: String = "\(version) (build \(buildNumber))"
 }

--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -19,6 +19,7 @@ BUNDLE_ID="com.lemonadeinc.textenhancer.v2"
 INSTALL_PATH="/Applications/${APP_NAME}.app"
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="${PROJECT_DIR}/build"
+CODE_SIGN_ARGS=("CODE_SIGNING_ALLOWED=NO")
 
 echo -e "${BLUE}🚀 TextEnhancer Build & Install Script${NC}"
 echo -e "${YELLOW}⚠️  CRITICAL: This app requires accessibility permissions to function${NC}"
@@ -66,6 +67,7 @@ cd "${PROJECT_DIR}"
 xcodebuild -scheme "${APP_NAME}" \
            -configuration Release \
            -derivedDataPath "${BUILD_DIR}" \
+           "${CODE_SIGN_ARGS[@]}" \
            clean build \
            | grep -E "(error|warning|SUCCEEDED|FAILED)" || true
 
@@ -79,7 +81,8 @@ echo -e "${GREEN}   ✅ Build completed successfully${NC}"
 # Step 5: Verify code signing
 echo -e "${BLUE}5. Verifying code signing and bundle ID...${NC}"
 BUILT_APP="${BUILD_DIR}/Build/Products/Release/${APP_NAME}.app"
-ACTUAL_BUNDLE_ID=$(codesign -dv --verbose=4 "${BUILT_APP}" 2>&1 | grep "Identifier=" | cut -d'=' -f2)
+codesign --force --deep --sign - "${BUILT_APP}"
+ACTUAL_BUNDLE_ID=$(codesign -dv --verbose=4 "${BUILT_APP}" 2>&1 | grep "^Identifier=" | cut -d'=' -f2)
 
 if [ "$ACTUAL_BUNDLE_ID" != "$BUNDLE_ID" ]; then
     echo -e "${RED}❌ ERROR: Built app has wrong bundle ID: $ACTUAL_BUNDLE_ID (expected: $BUNDLE_ID)${NC}"


### PR DESCRIPTION
## Summary
- Fix the Documentation workflow to scan `TextEnhancer/` instead of the nonexistent `Sources/` directory.
- Update the Pages artifact upload action to `actions/upload-pages-artifact@v4`.
- Prevent test-host notification permission requests from crashing SwiftPM tests.
- Make local install builds resilient to stale Apple signing identities by ad-hoc signing the built app.
- Write the app version directly to `~/Library/Logs/TextEnhancer/debug.log` and bump the build number to 1024.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); puts "yaml ok"'`
- Docs generation shell fragment against `TextEnhancer` source path.
- `swift test --filter DebugModeIntegrationTests/testDebugModeAppRestartPersistence`
- `./build-and-install.sh`
- Verified `/Applications/TextEnhancer.app` process is running.
- Verified bundle identifier `com.lemonadeinc.textenhancer.v2`.
- Verified debug log contains `Version: 1.0.3 (build 1024)`.