### PR TITLE
ci(deps): bump swift-actions/setup-swift from 1 to 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Swift ${{ matrix.swift-version }}
-      uses: swift-actions/setup-swift@v1
+      uses: swift-actions/setup-swift@v2
       with:
         swift-version: ${{ matrix.swift-version }}
 
@@ -106,7 +106,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Swift 5.9
-      uses: swift-actions/setup-swift@v1
+      uses: swift-actions/setup-swift@v2
       with:
         swift-version: '5.9'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Swift
-      uses: swift-actions/setup-swift@v1
+      uses: swift-actions/setup-swift@v2
       with:
         swift-version: '5.9'
 
@@ -115,7 +115,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Swift
-      uses: swift-actions/setup-swift@v1
+      uses: swift-actions/setup-swift@v2
       with:
         swift-version: '5.9'
 


### PR DESCRIPTION
## Summary
- Replaces the stale Dependabot PR #5 with a clean branch rebased on current `main`.
- Updates `swift-actions/setup-swift` from v1 to v2 in CI and docs workflows.

## Verification
- Workflow-only change; checked the branch diff against `main` contains only the expected setup-swift updates.